### PR TITLE
Version 2.10.2 - TRACE Domain Update

### DIFF
--- a/src/TRACE/TRACE.sol
+++ b/src/TRACE/TRACE.sol
@@ -59,7 +59,7 @@ error Unauthorized();
 ///      - Story Contract backed by T.R.A.C.E. chip functionality
 ///      - individual token royalty overrides
 /// @author transientlabs.xyz
-/// @custom:version 2.10.1
+/// @custom:version 2.10.2
 contract TRACE is
     Initializable,
     ERC721Upgradeable,
@@ -97,7 +97,7 @@ contract TRACE is
                                 State Variables
     //////////////////////////////////////////////////////////////////////////*/
 
-    string public constant VERSION = "2.10.1";
+    string public constant VERSION = "2.10.2";
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     TRACERSRegistry public tracersRegistry;
     uint256 private _counter; // token ids
@@ -155,7 +155,7 @@ contract TRACE is
         __EIP2981TL_init(defaultRoyaltyRecipient, defaultRoyaltyPercentage);
         __OwnableAccessControl_init(initOwner);
         __StoryContractUpgradeable_init(true);
-        __EIP712_init(name, "1");
+        __EIP712_init("T.R.A.C.E.", "1");
 
         // add admins
         _setRole(ADMIN_ROLE, admins, true);

--- a/test/TRACE/TRACE.t.sol
+++ b/test/TRACE/TRACE.t.sol
@@ -58,7 +58,7 @@ contract TRACETest is Test {
         trace.initialize("Test TRACE", "TRACE", royaltyRecipient, 1000, address(this), admins, address(registry));
 
         // sig utils
-        sigUtils = new TRACESigUtils("Test TRACE", "1", address(trace));
+        sigUtils = new TRACESigUtils("1", address(trace));
     }
 
     /// @notice Initialization Tests
@@ -579,7 +579,7 @@ contract TRACETest is Test {
         trace.setTracersRegistry(address(registry));
 
         // sig utils
-        sigUtils = new TRACESigUtils(name, "1", address(trace));
+        sigUtils = new TRACESigUtils("1", address(trace));
 
         // get nonce
         uint256 nonce = trace.getTokenNonce(1);

--- a/test/utils/TRACESigUtils.sol
+++ b/test/utils/TRACESigUtils.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.19;
 contract TRACESigUtils {
     bytes32 internal DOMAIN_SEPARATOR;
 
-    constructor(string memory name, string memory version, address verifyingContract) {
+    constructor(string memory version, address verifyingContract) {
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-                keccak256(bytes(name)),
+                keccak256("T.R.A.C.E."),
                 keccak256(bytes(version)),
                 block.chainid,
                 verifyingContract


### PR DESCRIPTION
updated trace EIP-712 domain to be 'T.R.A.C.E.' rather than the name of the contract. Only affects signing the message