### PR TITLE
3.6.0 ERC721TL Rendering Contract

### DIFF
--- a/src/erc-1155/ERC1155TL.sol
+++ b/src/erc-1155/ERC1155TL.sol
@@ -41,7 +41,7 @@ contract ERC1155TL is
                                 State Variables
     //////////////////////////////////////////////////////////////////////////*/
 
-    string public constant VERSION = "3.1.0";
+    string public constant VERSION = "3.5.0";
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant APPROVED_MINT_CONTRACT = keccak256("APPROVED_MINT_CONTRACT");
     uint256 private _counter;

--- a/src/erc-721/multi-metadata/CollectorsChoice.sol
+++ b/src/erc-721/multi-metadata/CollectorsChoice.sol
@@ -61,7 +61,7 @@ contract CollectorsChoice is
                                 State Variables
     //////////////////////////////////////////////////////////////////////////*/
 
-    string public constant VERSION = "3.1.1";
+    string public constant VERSION = "3.5.0";
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant APPROVED_MINT_CONTRACT = keccak256("APPROVED_MINT_CONTRACT");
     uint256 private _counter; // token ids

--- a/src/erc-721/multi-metadata/ERC7160TL.sol
+++ b/src/erc-721/multi-metadata/ERC7160TL.sol
@@ -68,7 +68,7 @@ contract ERC7160TL is
                                 State Variables
     //////////////////////////////////////////////////////////////////////////*/
 
-    string public constant VERSION = "3.1.1";
+    string public constant VERSION = "3.5.0";
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant APPROVED_MINT_CONTRACT = keccak256("APPROVED_MINT_CONTRACT");
     uint256 private _counter; // token ids

--- a/src/erc-721/multi-metadata/ERC7160TLEditions.sol
+++ b/src/erc-721/multi-metadata/ERC7160TLEditions.sol
@@ -60,7 +60,7 @@ contract ERC7160TLEditions is
                                 State Variables
     //////////////////////////////////////////////////////////////////////////*/
 
-    string public constant VERSION = "3.2.0";
+    string public constant VERSION = "3.5.0";
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant APPROVED_MINT_CONTRACT = keccak256("APPROVED_MINT_CONTRACT");
     uint256 private _counter; // token ids

--- a/src/erc-721/trace/TRACE.sol
+++ b/src/erc-721/trace/TRACE.sol
@@ -66,7 +66,7 @@ contract TRACE is
                                 State Variables
     //////////////////////////////////////////////////////////////////////////*/
 
-    string public constant VERSION = "3.1.2";
+    string public constant VERSION = "3.5.0";
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant APPROVED_MINT_CONTRACT = keccak256("APPROVED_MINT_CONTRACT");
     ITRACERSRegistry public tracersRegistry;

--- a/src/interfaces/IMutableMetadata.sol
+++ b/src/interfaces/IMutableMetadata.sol
@@ -3,17 +3,18 @@ pragma solidity 0.8.22;
 
 /// @title IMutableMetadata.sol
 /// @notice Interface for Mutable Metadata
-/// @dev Interface id = 0xd31af484
+/// @dev Interface id = 0x64eb24f6
 /// @author transientlabs.xyz
-/// @custom:version 3.3.0
+/// @custom:version 3.6.0
 interface IMutableMetadata {
-    /*//////////////////////////////////////////////////////////////////////////
-                                    Functions
-    //////////////////////////////////////////////////////////////////////////*/
-
     /// @notice Function to mutate the metadata for an ERC-721 token
-    /// @dev Must be called by contract owner, admin, or approved mint contract
+    /// @dev Must be called by contract owner or admin
     /// @dev MUST emit a `MetadataUpdate` event from ERC-4906
     /// @param tokenId The token to push the metadata update to
     function updateTokenUri(uint256 tokenId, string calldata newUri) external;
+
+    /// @notice Function to set the rendering contract
+    /// @dev Must be called by contract owner or admin
+    /// @dev MUST emit a `MetadataUpdate` event from ERC-4906
+    function setRenderingContract(address newRenderingContract) external;
 }

--- a/src/interfaces/IRenderingContract.sol
+++ b/src/interfaces/IRenderingContract.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.22;
+
+/// @title Rendering Contract Interface
+/// @notice Official rendering contract interface that specfies a universal interface for custom rendering contracts
+/// @dev Interface id = 0xc87b56dd
+/// @author transientlabs.xyz
+/// @custom:version 3.6.0
+interface IRenderingContract {
+    /// @notice Function for getting the URI for a token id
+    /// @param tokenId The token id
+    /// @return string To the token uri
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}

--- a/test/erc-721/multi-metadata/ERC7160TLEditions.t.sol
+++ b/test/erc-721/multi-metadata/ERC7160TLEditions.t.sol
@@ -3302,7 +3302,7 @@ contract ERC7160TLEditionsTest is Test {
         vm.prank(address(1));
         tokenContract.unpinTokenURI(1);
     }
-    
+
     /// @notice test locked tokens stuff
     function test_lockedTokens(address hacker) public {
         vm.assume(hacker != address(this));

--- a/test/utils/MockRenderingContract.sol
+++ b/test/utils/MockRenderingContract.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.22;
+
+import {IRenderingContract} from "src/interfaces/IRenderingContract.sol";
+import {Strings} from "@openzeppelin-contracts-5.0.2/utils/Strings.sol";
+
+contract MockRenderingContract is IRenderingContract {
+
+    using Strings for uint256;
+
+    string public baseUri = "renderingContract/";
+
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        return string(abi.encodePacked(baseUri, tokenId.toString()));
+    }
+}


### PR DESCRIPTION
Rendering contract added to ERC721TL so that token uri creation can be delegated to another contract. This allows for reveal-style metadata, onchain metadata, and more.